### PR TITLE
need to audit again because for docker-action in pre-commit linting

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,19 +18,21 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@248ae51c2e8cc9622ecf50685c8bf7150c6e8813 # tag=v1.4
       with:
-        egress-policy: block
-        disable-telemetry: true
-        allowed-endpoints: >
-          auth.docker.io:443
-          codecov.io:443
-          files.pythonhosted.org:443
-          github.com:443
-          production.cloudflare.docker.com:443
-          pypi.org:443
-          raw.githubusercontent.com:443
-          registry-1.docker.io:443
-          storage.googleapis.com:443
-          uploader.codecov.io:443
+        egress-policy: audit
+        disable-telemetry: false
+        # egress-policy: block
+        # disable-telemetry: true
+        # allowed-endpoints: >
+        #   auth.docker.io:443
+        #   codecov.io:443
+        #   files.pythonhosted.org:443
+        #   github.com:443
+        #   production.cloudflare.docker.com:443
+        #   pypi.org:443
+        #   raw.githubusercontent.com:443
+        #   registry-1.docker.io:443
+        #   storage.googleapis.com:443
+        #   uploader.codecov.io:443
 
     - name: "Checkout"
       uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3


### PR DESCRIPTION
Adding the docker-action to the pre-commit linters causes an egress issue on the test action.  Open up for auditing again to nail down updated egress needs.

Issue: #134 