### PR TITLE
Do not run tests workflow on gh-pages branch

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
       - '*'
       - '!gh-pages'
       # Run on all branches except gh-pages
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 # .github/workflows/tests.yml
 name: Tests
-on: push
+
+on:
+  push:
+    branches:
+      - '*'
+      - '!gh-pages'
+      # Run on all branches except gh-pages
 
 permissions:
   contents: read


### PR DESCRIPTION
When a merge to main happens, the benchmark action adds the latest benchmark data to the `gh-pages` branch. The code has already passed the tests workflow on the PR branch.  The test action has been triggering an unneeded and failing run of the tests workflow when the benchmark changes are pushed to `gh-pages`. Make that stop.
