### PR TITLE
Unpin semgrep image

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -17,7 +17,7 @@ jobs:
     name: Semgrep
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep:sha-437101c # tag=v1
+      image: returntocorp/semgrep # unpin to resolve version issue :sha-437101c # tag=v1
     # Skip any PR created by dependabot to avoid permission issues
     if: (github.actor != 'dependabot[bot]')
 


### PR DESCRIPTION
In order to determine if the semgrep workflow problems are due to pinning to an old version, troubleshoot by unpinning the image version.