### PR TITLE
Update renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -24,6 +24,10 @@
       "matchUpdateTypes": ["patch", "minor", "digest"],
       "groupName": "devDependencies (non-major)",
       "automerge": true
+    },
+    {
+      "matchPackageNames": ["zricethezav/gitleaks"],
+      "allowedVersions": "<=8.21.2"
     }
   ],
   "pre-commit": {


### PR DESCRIPTION
We use gitleaks in the pre-commit hooks to detect credentials and such from being uploaded to GitHub. However, recent versions, past v8.21.2, break the build.

Until the behavior of gitleaks is restored, or the build is configured so newer gitleaks don't break the build, or until gitleaks is replaced with a similar tool, I want to configure Renovate to keep the version no higher than v8.21.2.

## Summary by Sourcery

CI:
- Pin gitleaks to v8.21.2 to prevent breaking the build.