### PR TITLE
Trouble shot. Reharden theworkflow.

### DIFF
--- a/.github/workflows/scorecards.yaml
+++ b/.github/workflows/scorecards.yaml
@@ -27,16 +27,22 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@cb605e52c26070c328afc4562f0b4ada7618a84e # v2.10.4
         with:
-          egress-policy: audit
+          egress-policy: block
           disable-telemetry: false
           allowed-endpoints: >
-            api.github.com:443
-            api.osv.dev:443
-            bestpractices.coreinfrastructure.org:443
             codeload.github.com:443
             github.com:443
             pipelines.actions.githubusercontent.com:443
+            api.deps.dev:443
+            api.github.com:443
+            api.osv.dev:443
+            api.scorecard.dev:443
+            fulcio.sigstore.dev:443
+            github.com:443
             oss-fuzz-build-logs.storage.googleapis.com:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
+            www.bestpractices.dev:443
 
       - name: "Checkout code"
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Block network egress by default for the Scorecards workflow, only allowing connections to necessary endpoints including api.deps.dev, api.github.com, api.osv.dev, api.scorecard.dev, codeload.github.com, fulcio.sigstore.dev, github.com, oss-fuzz-build-logs.storage.googleapis.com, pipelines.actions.githubusercontent.com, rekor.sigstore.dev, tuf-repo-cdn.sigstore.dev, and www.bestpractices.dev